### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ flow(
   applyCachingHeaders(pluginData, pluginOptions),
   mapUserLinkAllPageHeaders(pluginData, pluginOptions),
   applyLinkHeaders(pluginData, pluginOptions),
-  applyTransfromHeaders(pluginOptions),
+  applyTransformHeaders(pluginOptions),
   saveHeaders(pluginData)
 )
 


### PR DESCRIPTION
Fix typo with function name (`applyTransfromHeaders` -> `applyTransformHeaders`)